### PR TITLE
fix: fix typo in method name

### DIFF
--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -92,7 +92,7 @@ impl StivaleStruct {
             .map(|addr| unsafe { &*(addr as *const StivaleEpochTag) })
     }
 
-    pub fn frimware(&self) -> Option<&'static StivaleFirmwareTag> {
+    pub fn firmware(&self) -> Option<&'static StivaleFirmwareTag> {
         self.get_tag(0x359d837855e3858c)
             .map(|addr| unsafe { &*(addr as *const StivaleFirmwareTag) })
     }


### PR DESCRIPTION
Rename `frimware` to `firmware`.