### PR TITLE
Use dynamically sized slices to prevent UB from reading an array out of bounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stivale-boot"
 description = "Rust crate for parsing stivale and stivale 2 structures"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["Anhad Singh <andypythonappdeveloper@gmail.com>"]
 license = "MIT/Apache-2.0"
 edition = "2018"

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -2,6 +2,8 @@
 //! modern version of the legacy stivale protocol which provides the kernel with most of the features
 //! one may need. The stivale2 protocol also supports 32-bit systems.
 
+use core::mem;
+
 mod header;
 mod tag;
 mod utils;
@@ -71,8 +73,14 @@ impl StivaleStruct {
     }
 
     pub fn memory_map(&self) -> Option<&'static StivaleMemoryMapTag> {
-        self.get_tag(0x2187f79e8612de07)
-            .map(|addr| unsafe { &*(addr as *const StivaleMemoryMapTag) })
+        self.get_tag(0x2187f79e8612de07).map(|addr| {
+            let ptr = addr as *mut u8;
+            unsafe {
+                let count = *(ptr.add(mem::size_of::<StivaleTagHeader>()) as *const u64);
+                let memory_map_ptr = StivaleMemoryMapTag::new_from_ptr_count(ptr as *mut (), count);
+                &*memory_map_ptr
+            }
+        })
     }
 
     pub fn framebuffer(&self) -> Option<&'static StivaleFramebufferTag> {
@@ -81,8 +89,14 @@ impl StivaleStruct {
     }
 
     pub fn edid_info(&self) -> Option<&'static StivaleEdidInfoTag> {
-        self.get_tag(0x968609d7af96b845)
-            .map(|addr| unsafe { &*(addr as *const StivaleEdidInfoTag) })
+        self.get_tag(0x968609d7af96b845).map(|addr| {
+            let ptr = addr as *mut u8;
+            unsafe {
+                let count = *(ptr.add(mem::size_of::<StivaleTagHeader>()) as *const u64);
+                let edid_ptr = StivaleEdidInfoTag::new_from_ptr_count(ptr as *mut (), count);
+                &*edid_ptr
+            }
+        })
     }
 
     #[allow(deprecated)]
@@ -97,8 +111,14 @@ impl StivaleStruct {
     }
 
     pub fn modules(&self) -> Option<&'static StivaleModuleTag> {
-        self.get_tag(0x4b6fe466aade04ce)
-            .map(|addr| unsafe { &*(addr as *const StivaleModuleTag) })
+        self.get_tag(0x4b6fe466aade04ce).map(|addr| {
+            let ptr = addr as *mut u8;
+            unsafe {
+                let count = *(ptr.add(mem::size_of::<StivaleTagHeader>()) as *const u64);
+                let module_ptr = StivaleModuleTag::new_from_ptr_count(ptr as *mut (), count);
+                &*module_ptr
+            }
+        })
     }
 
     pub fn rsdp(&self) -> Option<&'static StivaleRsdpTag> {
@@ -137,13 +157,27 @@ impl StivaleStruct {
     }
 
     pub fn smp(&self) -> Option<&'static StivaleSmpTag> {
-        self.get_tag(0x34d1d96339647025)
-            .map(|addr| unsafe { &*(addr as *const StivaleSmpTag) })
+        self.get_tag(0x34d1d96339647025).map(|addr| {
+            let ptr = addr as *mut u8;
+            unsafe {
+                // +32 calculated from the definition of the struct, offset to the cpu_count
+                let count = *(ptr.add(32) as *const u64);
+                let smp_ptr = StivaleSmpTag::new_from_ptr_count(ptr as *mut (), count);
+                &*smp_ptr
+            }
+        })
     }
 
     pub fn smp_mut(&mut self) -> Option<&'static mut StivaleSmpTag> {
-        self.get_tag(0x34d1d96339647025)
-            .map(|addr| unsafe { &mut *(addr as *mut StivaleSmpTag) })
+        self.get_tag(0x34d1d96339647025).map(|addr| {
+            let ptr = addr as *mut u8;
+            unsafe {
+                // +32 calculated from the definition of the struct, offset to the cpu_count
+                let count = *(ptr.add(32) as *const u64);
+                let smp_ptr = StivaleSmpTag::new_from_ptr_count(ptr as *mut (), count);
+                &mut *smp_ptr
+            }
+        })
     }
 
     pub fn pxe_info(&self) -> Option<&'static StivalePxeInfoTag> {
@@ -172,8 +206,14 @@ impl StivaleStruct {
     }
 
     pub fn pmrs(&self) -> Option<&'static StivalePmrsTag> {
-        self.get_tag(0x5df266a64047b6bd)
-            .map(|addr| unsafe { &*(addr as *const StivalePmrsTag) })
+        self.get_tag(0x5df266a64047b6bd).map(|addr| {
+            let ptr = addr as *mut u8;
+            unsafe {
+                let count = *(ptr.add(mem::size_of::<StivaleTagHeader>()) as *const u64);
+                let pmrs_ptr = StivalePmrsTag::new_from_ptr_count(ptr as *mut (), count);
+                &*pmrs_ptr
+            }
+        })
     }
 
     pub fn kernel_base_addr(&self) -> Option<&'static StivaleKernelBaseAddressTag> {

--- a/src/v2/tag.rs
+++ b/src/v2/tag.rs
@@ -161,14 +161,21 @@ pub struct StivaleMemoryMapTag {
     pub header: StivaleTagHeader,
     /// Total length of the memory map entries.
     pub entries_len: u64,
-    /// Pointer to the memory map entries.
-    pub entry_array: [StivaleMemoryMapEntry; 0],
+    /// The memory map entries.
+    pub entry_array: [StivaleMemoryMapEntry],
 }
 
 impl StivaleMemoryMapTag {
     /// Return's memory map entries pointer as a rust slice.
     pub fn as_slice(&self) -> &[StivaleMemoryMapEntry] {
         unsafe { core::slice::from_raw_parts(self.entry_array.as_ptr(), self.entries_len as usize) }
+    }
+
+    /// # Safety
+    /// ptr must be a pointer to a properly initialized StivaleMemoryMapTag struct with `mem_entry_count` entries in the `entry_array`
+    pub unsafe fn new_from_ptr_count(ptr: *mut (), mem_entry_count: u64) -> *mut Self {
+        let slice_ptr = core::ptr::slice_from_raw_parts_mut(ptr, mem_entry_count as usize); // construct a pointer to a slice that has the appropriate length metadata
+        slice_ptr as *mut Self // change the pointer to point to the proper struct, the length metadata is unchanged, so the DST field has the same length
     }
 
     /// Returns an iterator over all the memory regions.
@@ -273,14 +280,21 @@ pub struct StivaleEdidInfoTag {
     pub header: StivaleTagHeader,
     /// Length of the EDID information array.
     pub edid_len: u64,
-    /// Pointer to the EDID information array.
-    pub info_array: [u8; 0],
+    /// The variable length EDID information array.
+    pub info_array: [u8],
 }
 
 impl StivaleEdidInfoTag {
     /// Return's the EDID information pointer as a rust slice.
     pub fn as_slice(&self) -> &[u8] {
         unsafe { core::slice::from_raw_parts(self.info_array.as_ptr(), self.edid_len as usize) }
+    }
+
+    /// # Safety
+    /// ptr must be a pointer to a properly initialized StivaleEdidInfoTag struct with `edid_count` entries in the `info_array`
+    pub unsafe fn new_from_ptr_count(ptr: *mut (), edid_count: u64) -> *mut Self {
+        let slice_ptr = core::ptr::slice_from_raw_parts_mut(ptr, edid_count as usize); // construct a pointer to a slice that has the appropriate length metadata
+        slice_ptr as *mut Self // change the pointer to point to the proper struct, the length metadata is unchanged, so the DST field has the same length
     }
 }
 
@@ -356,8 +370,8 @@ pub struct StivaleModuleTag {
     pub header: StivaleTagHeader,
     /// Length of the modules array.
     pub module_len: u64,
-    /// Pointer to the modules array.
-    pub modules_array: [StivaleModule; 0],
+    /// The variable length modules array.
+    pub modules_array: [StivaleModule],
 }
 
 impl StivaleModuleTag {
@@ -375,6 +389,13 @@ impl StivaleModuleTag {
         unsafe {
             core::slice::from_raw_parts(self.modules_array.as_ptr(), self.module_len as usize)
         }
+    }
+
+    /// # Safety
+    /// ptr must be a pointer to a properly initialized StivaleModuleTag struct with `module_count` entries in the `modules_array`
+    pub unsafe fn new_from_ptr_count(ptr: *mut (), module_count: u64) -> *mut Self {
+        let slice_ptr = core::ptr::slice_from_raw_parts_mut(ptr, module_count as usize); // construct a pointer to a slice that has the appropriate length metadata
+        slice_ptr as *mut Self // change the pointer to point to the proper struct, the length metadata is unchanged, so the DST field has the same length
     }
 }
 
@@ -434,8 +455,8 @@ pub struct StivaleSmpTag {
     pub unused: u32,
     /// The total number of logical CPUs (including BSP).
     cpu_count: u64,
-    /// Pointer to the SMP info array (including BSP).
-    pub smp_info_array: [StivaleSmpInfo; 0],
+    /// The variable length SMP info array (including BSP).
+    pub smp_info_array: [StivaleSmpInfo],
 }
 
 impl StivaleSmpTag {
@@ -474,6 +495,13 @@ impl StivaleSmpTag {
     /// struct must not be mutated any further.
     pub unsafe fn as_slice_mut(&mut self) -> &mut [StivaleSmpInfo] {
         core::slice::from_raw_parts_mut(self.smp_info_array.as_mut_ptr(), self.cpu_count as usize)
+    }
+
+    /// # Safety
+    /// ptr must be a pointer to a properly initialized StivaleSmpTag struct with `cpu_count` entries in the `smp_info_array`
+    pub unsafe fn new_from_ptr_count(ptr: *mut (), cpu_count: u64) -> *mut Self {
+        let slice_ptr = core::ptr::slice_from_raw_parts_mut(ptr, cpu_count as usize); // construct a pointer to a slice that has the appropriate length metadata
+        slice_ptr as *mut Self // change the pointer to point to the proper struct, the length metadata is unchanged, so the DST field has the same length
     }
 }
 
@@ -549,13 +577,20 @@ pub struct StivalePmrsTag {
     /// Count of PMRs in following array.
     pub pmr_count: u64,
     /// Array of PMR structs.
-    pub pmrs: [StivalePmr; 0],
+    pub pmrs: [StivalePmr],
 }
 
 impl StivalePmrsTag {
     /// Return's the PMRs array pointer as a rust slice.
     pub fn as_slice(&self) -> &[StivalePmr] {
         unsafe { core::slice::from_raw_parts(self.pmrs.as_ptr(), self.pmr_count as usize) }
+    }
+
+    /// # Safety
+    /// ptr must be a pointer to a properly initialized StivalePmrsTag struct with `pmr_count` entries in the `prms` field
+    pub unsafe fn new_from_ptr_count(ptr: *mut (), pmr_count: u64) -> *mut Self {
+        let slice_ptr = core::ptr::slice_from_raw_parts_mut(ptr, pmr_count as usize); // construct a pointer to a slice that has the appropriate length metadata
+        slice_ptr as *mut Self // change the pointer to point to the proper struct, the length metadata is unchanged, so the DST field has the same length
     }
 }
 


### PR DESCRIPTION
**This is a breaking change due to changing the type of publicly accessible fields.  Bumps version to 0.3.0**

Using a `[T; 0]` to access more than 0 elements (that is, to access *any* data) at that location is undefined behavior.  This PR moves to a dynamically sized slice approach to not cause undefined behavior in that way and better mirrors the exact data layout of the data being accessed.