### PR TITLE
Add `stivale2_struct_tag_boot_volume` tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ categories = ["no-std"]
 
 [dependencies]
 bitflags = "1.3.2"
+uuid = { version = "0.8.2", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,7 @@ categories = ["no-std"]
 
 [dependencies]
 bitflags = "1.3.2"
-uuid = { version = "0.8.2", default-features = false }
+uuid = { version = "0.8.2", default-features = false, optional = true }
+
+[features]
+uuid = ["dep:uuid"]

--- a/src/v2/mod.rs
+++ b/src/v2/mod.rs
@@ -220,4 +220,9 @@ impl StivaleStruct {
         self.get_tag(0x060d78874a2a8af0)
             .map(|addr| unsafe { &*(addr as *const StivaleKernelBaseAddressTag) })
     }
+
+    pub fn boot_volume(&self) -> Option<&'static StivaleBootVolumeTag> {
+        self.get_tag(0x9b4358364c19ee62)
+            .map(|addr| unsafe { &*(addr as *const StivaleBootVolumeTag) })
+    }
 }

--- a/src/v2/tag.rs
+++ b/src/v2/tag.rs
@@ -1,6 +1,7 @@
 use core::marker::PhantomData;
 
 use super::header::StivaleSmpHeaderTagFlags;
+use uuid::Uuid;
 
 #[repr(C)]
 pub struct StivaleTagHeader {
@@ -623,4 +624,29 @@ pub struct StivaleKernelBaseAddressTag {
     pub header: StivaleTagHeader,
     pub physical_base_address: u64,
     pub virtual_base_address: u64,
+}
+
+bitflags::bitflags! {
+    pub struct StivaleBootVolumeTagFlags: u64 {
+        const VOLUME_GUID    = 1 << 0;
+        const PARTITION_GUID = 1 << 1;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[repr(C)]
+pub struct StivaleGuid(u32, u16, u16, [u8; 8]);
+
+impl From<StivaleGuid> for Uuid {
+    fn from(guid: StivaleGuid) -> Self {
+        unsafe { Self::from_fields(guid.0, guid.1, guid.2, &guid.3).unwrap_unchecked() }
+    }
+}
+
+#[repr(C)]
+pub struct StivaleBootVolumeTag {
+    pub header: StivaleTagHeader,
+    pub flags: StivaleBootVolumeTagFlags,
+    pub guid: StivaleGuid,
+    pub part_guid: StivaleGuid,
 }

--- a/src/v2/tag.rs
+++ b/src/v2/tag.rs
@@ -1,7 +1,6 @@
 use core::marker::PhantomData;
 
 use super::header::StivaleSmpHeaderTagFlags;
-use uuid::Uuid;
 
 #[repr(C)]
 pub struct StivaleTagHeader {
@@ -637,6 +636,7 @@ bitflags::bitflags! {
 #[repr(C)]
 pub struct StivaleGuid(u32, u16, u16, [u8; 8]);
 
+#[cfg(feature = "uuid")]
 impl From<StivaleGuid> for Uuid {
     fn from(guid: StivaleGuid) -> Self {
         unsafe { Self::from_fields(guid.0, guid.1, guid.2, &guid.3).unwrap_unchecked() }


### PR DESCRIPTION
Fixes #10

Here you go! This seemed like an important feature, especially for my hobby OS, which needs to basically fetch the entire rest of itself from the disk after two seconds; not knowing where that is would make it very difficult 🙃.

This PR also pulls in the `uuid` crate. While this feature doesn't exactly require it to exist, it does provide an `Into` implementation for convenience.